### PR TITLE
Add: dynamic attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All Notable changes to the `chief` application template will be documented in th
 principles.
 
 ## unreleased
+- Add: dynamic attributes. [https://thinktomorrow.github.io/package-docs/src/chief/managers.html#dynamic-attributes](view docs)
 
 ## 0.4.12 - 2020-03-18
 - Changed: passed the media api url from outside the js and vue scripts so the urls are in line with the rest of the admin
@@ -13,7 +14,6 @@ principles.
 - Fixed: quill editor did not save the content in the pagebuilder text module.
 
 ## 0.4.10 - 2020-03-16
-
 - Fixed: changing urls can now be saved again.
 
 ## 0.4.9 - 2020-03-11

--- a/src/DynamicAttributes/DynamicAttributes.php
+++ b/src/DynamicAttributes/DynamicAttributes.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Thinktomorrow\Chief\DynamicAttributes;

--- a/src/DynamicAttributes/DynamicAttributes.php
+++ b/src/DynamicAttributes/DynamicAttributes.php
@@ -13,6 +13,13 @@ class DynamicAttributes
         $this->values = $values;
     }
 
+    public static function fromRawValue($value): self
+    {
+        $value = is_null($value) ? [] : (is_array($value) ? $value : json_decode($value, true));
+
+        return new static((array) $value);
+    }
+
     public function has(string $key): bool
     {
         return ($this->get($key, '__NOTFOUND__') !== '__NOTFOUND__');
@@ -31,5 +38,10 @@ class DynamicAttributes
     public function all()
     {
         return $this->values;
+    }
+
+    public function toJson(): string
+    {
+        return json_encode($this->all());
     }
 }

--- a/src/DynamicAttributes/DynamicAttributes.php
+++ b/src/DynamicAttributes/DynamicAttributes.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Thinktomorrow\Chief\DynamicAttributes;
+
+class DynamicAttributes
+{
+    /** @var array */
+    private $values;
+
+    public function __construct(array $values)
+    {
+        $this->values = $values;
+    }
+
+    public function has(string $key): bool
+    {
+        return ($this->get($key, '__NOTFOUND__') !== '__NOTFOUND__');
+    }
+
+    public function get(string $key, $default = null)
+    {
+        return data_get($this->values, $key, $default);
+    }
+
+    public function set(string $key, $value)
+    {
+        data_set($this->values, $key, $value);
+    }
+
+    public function all()
+    {
+        return $this->values;
+    }
+}

--- a/src/DynamicAttributes/HasDynamicAttributes.php
+++ b/src/DynamicAttributes/HasDynamicAttributes.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace Thinktomorrow\Chief\DynamicAttributes;
+
+trait HasDynamicAttributes
+{
+    /**
+     * Method used by the save logic on eloquent. This way we can inject an json version of the
+     *dynamic attributes for saving into the database.
+     * @return mixed
+     */
+    public function getAttributes()
+    {
+        $attributes = $this->attributes;
+
+        $attributes[$this->getDynamicAttributesKey()] = json_encode($attributes[$this->getDynamicAttributesKey()]->all());
+
+        return $attributes;
+    }
+
+    public function setRawAttributes(array $attributes, $sync = false)
+    {
+        if (isset($attributes[$this->getDynamicAttributesKey()])) {
+            /*
+             * fill the dynamic attributes in a custom key, so this will not conflict with the original values.
+             * A custom key other than the column key is required because the trait is initialized before
+             * the original attributes of the model are filled in.
+            */
+            $attributes[$this->getDynamicAttributesKey()] = $this->convertToDynamicAttributes($attributes[$this->getDynamicAttributesKey()]);
+        }
+
+        return parent::setRawAttributes($attributes, $sync);
+    }
+
+    public function fill(array $attributes)
+    {
+        if (isset($attributes[$this->getDynamicAttributesKey()])) {
+            /*
+             * fill the dynamic attributes in a custom key, so this will not conflict with the original values.
+             * A custom key other than the column key is required because the trait is initialized before
+             * the original attributes of the model are filled in.
+            */
+            $attributes[$this->getDynamicAttributesKey()] = $this->convertToDynamicAttributes($attributes[$this->getDynamicAttributesKey()]);
+        }
+
+        return parent::fill($attributes);
+    }
+
+    private function convertToDynamicAttributes($value): DynamicAttributes
+    {
+        $value = is_array($value) ? $value : json_decode($value, true);
+
+        /*
+         * fill the dynamic attributes in a custom key, so this will not conflict with the original values.
+         * A custom key other than the column key is required because the trait is initialized before
+         * the original attributes of the model are filled in.
+        */
+        return new DynamicAttributes((array) $value);
+    }
+
+    public function getAttribute($key)
+    {
+        // Fetching a native models' attribute has precedence over a dynamic attribute.
+        if (array_key_exists($key, $this->attributes)){
+            return parent::getAttribute($key);
+        }
+
+        $locale = app()->getLocale();
+
+        // If the dynamic attributes contain a localized value, this has preference over any non-localized.
+        foreach(["{$locale}.$key", $key] as $k){
+            if($this->dynamicAttributesInstance()->has($k)){
+                return $this->dynamic($k);
+            }
+        }
+
+        return parent::getAttribute($key);
+    }
+
+    public function setAttribute($key, $value)
+    {
+        if ($this->shouldBeSetAsDynamicAttribute($key)){
+            return $this->dynamicAttributesInstance()->set($key, $value);
+        }
+
+        return parent::setAttribute($key, $value);
+    }
+
+    protected function shouldBeSetAsDynamicAttribute($key): bool
+    {
+        if(array_key_exists($key, $this->attributes) || !array_key_exists($this->getDynamicAttributesKey(), $this->attributes)) {
+            return false;
+        }
+
+        return in_array($key, $this->getDynamicAttributes());
+    }
+
+    public function dynamic(string $key, string $index = null)
+    {
+        return $this->dynamicAttributesInstance()->get($index ? "$index.$key" : $key);
+    }
+
+    protected function dynamicAttributesInstance(): DynamicAttributes
+    {
+        return $this->attributes[$this->getDynamicAttributesKey()];
+    }
+
+    protected function getDynamicAttributesKey()
+    {
+        return defined('static::DYNAMIC_ATTRIBUTES_KEY') ? static::DYNAMIC_ATTRIBUTES_KEY : 'values';
+    }
+
+    protected function getDynamicAttributes(): array
+    {
+        return property_exists($this, 'dynamicAttributes') ? $this->dynamicAttributes : [];
+    }
+}

--- a/src/DynamicAttributes/HasDynamicAttributes.php
+++ b/src/DynamicAttributes/HasDynamicAttributes.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Thinktomorrow\Chief\DynamicAttributes;
@@ -17,7 +18,7 @@ trait HasDynamicAttributes
 
     public function isDynamicKey($key): bool
     {
-        if(array_key_exists($key, $this->attributes)) {
+        if (array_key_exists($key, $this->attributes)) {
             return false;
         }
 
@@ -73,14 +74,14 @@ trait HasDynamicAttributes
      */
     public function getAttribute($key)
     {
-        if (!$this->isDynamicKey($key)){
+        if (!$this->isDynamicKey($key)) {
             return parent::getAttribute($key);
         }
 
         $locale = app()->getLocale();
 
-        foreach(["{$locale}.$key", $key] as $k){
-            if($this->dynamicAttributesInstance()->has($k)){
+        foreach (["{$locale}.$key", $key] as $k) {
+            if ($this->dynamicAttributesInstance()->has($k)) {
                 return $this->dynamic($k);
             }
         }
@@ -91,7 +92,7 @@ trait HasDynamicAttributes
     /* Part of the custom cast */
     public function setAttribute($key, $value)
     {
-        if ($this->isDynamicKey($key)){
+        if ($this->isDynamicKey($key)) {
             return $this->setDynamic($key, $value);
         }
 
@@ -101,9 +102,9 @@ trait HasDynamicAttributes
     /* Part of the custom cast */
     protected function dynamicAttributesInstance(): DynamicAttributes
     {
-        if(!isset($this->attributes[$this->getDynamicKey()])) {
+        if (!isset($this->attributes[$this->getDynamicKey()])) {
             $this->attributes[$this->getDynamicKey()] = DynamicAttributes::fromRawValue([]);
-        } elseif(!($raw = $this->attributes[$this->getDynamicKey()]) instanceof DynamicAttributes) {
+        } elseif (!($raw = $this->attributes[$this->getDynamicKey()]) instanceof DynamicAttributes) {
             $this->attributes[$this->getDynamicKey()] = DynamicAttributes::fromRawValue($raw);
         }
 
@@ -120,7 +121,7 @@ trait HasDynamicAttributes
      */
     private function injectDynamicAttributes(array $attributes, bool $castToObject = true): array
     {
-        if(isset($attributes[$this->getDynamicKey()])) {
+        if (isset($attributes[$this->getDynamicKey()])) {
             $attributes[$this->getDynamicKey()] = $castToObject
                 ? DynamicAttributes::fromRawValue($attributes[$this->getDynamicKey()])
                 : $attributes[$this->getDynamicKey()]->toJson();

--- a/src/Fields/SavingFields.php
+++ b/src/Fields/SavingFields.php
@@ -109,10 +109,7 @@ trait SavingFields
         }
 
         // By default we assume the key matches the attribute / column naming
-        // If value is not present in the request input, we'll ignore it.
-        if($request->has($field->getKey())) {
-            $this->model->{$field->getColumn()} = $request->input($field->getKey());
-        }
+        $this->model->{$field->getColumn()} = $request->input($field->getKey());
     }
 
     private function saveQueuedFields()

--- a/src/Fields/SavingFields.php
+++ b/src/Fields/SavingFields.php
@@ -116,9 +116,9 @@ trait SavingFields
     {
         $queued_translations = $this->queued_translations;
 
-        foreach($queued_translations as $locale => $translations){
-            foreach($translations as $key => $value) {
-                if(method_exists($this->model, 'isDynamicKey') && $this->model->isDynamicKey($key)) {
+        foreach ($queued_translations as $locale => $translations) {
+            foreach ($translations as $key => $value) {
+                if (method_exists($this->model, 'isDynamicKey') && $this->model->isDynamicKey($key)) {
                     $this->model->setDynamic($key, $value, $locale);
 
                     // Remove from queued translations
@@ -126,7 +126,7 @@ trait SavingFields
                 }
 
                 // remove any empty locale entries
-                if(empty($queued_translations[$locale])) {
+                if (empty($queued_translations[$locale])) {
                     unset($queued_translations[$locale]);
                 }
             }

--- a/src/Fields/SavingFields.php
+++ b/src/Fields/SavingFields.php
@@ -109,7 +109,10 @@ trait SavingFields
         }
 
         // By default we assume the key matches the attribute / column naming
-        $this->model->{$field->getColumn()} = $request->input($field->getKey());
+        // If value is not present in the request input, we'll ignore it.
+        if($request->has($field->getKey())) {
+            $this->model->{$field->getColumn()} = $request->input($field->getKey());
+        }
     }
 
     private function saveQueuedFields()
@@ -118,7 +121,7 @@ trait SavingFields
 
         foreach($queued_translations as $locale => $translations){
             foreach($translations as $key => $value) {
-                if(method_exists($this->model, 'isDynamicAttributeKey') && $this->model->isDynamicAttributeKey($key)) {
+                if(method_exists($this->model, 'isDynamicKey') && $this->model->isDynamicKey($key)) {
                     $this->model->setDynamic($key, $value, $locale);
 
                     // Remove from queued translations

--- a/src/Fields/Types/AbstractField.php
+++ b/src/Fields/Types/AbstractField.php
@@ -245,7 +245,7 @@ abstract class AbstractField
             }
 
             if ($locale && $this->isLocalized()) {
-                if(method_exists($model, 'isDynamicAttributeKey') && $model->isDynamicAttributeKey($this->getColumn())){
+                if(method_exists($model, 'isDynamicKey') && $model->isDynamicKey($this->getColumn())){
                     return $model->dynamic($this->getColumn(), $locale);
                 }
 

--- a/src/Fields/Types/AbstractField.php
+++ b/src/Fields/Types/AbstractField.php
@@ -245,6 +245,10 @@ abstract class AbstractField
             }
 
             if ($locale && $this->isLocalized()) {
+                if(method_exists($model, 'isDynamicAttributeKey') && $model->isDynamicAttributeKey($this->getColumn())){
+                    return $model->dynamic($this->getColumn(), $locale);
+                }
+
                 return $model->getTranslationFor($this->getColumn(), $locale);
             }
 

--- a/src/Fields/Types/AbstractField.php
+++ b/src/Fields/Types/AbstractField.php
@@ -245,7 +245,7 @@ abstract class AbstractField
             }
 
             if ($locale && $this->isLocalized()) {
-                if(method_exists($model, 'isDynamicKey') && $model->isDynamicKey($this->getColumn())){
+                if (method_exists($model, 'isDynamicKey') && $model->isDynamicKey($this->getColumn())) {
                     return $model->dynamic($this->getColumn(), $locale);
                 }
 

--- a/tests/Feature/Management/Fakes/ManagedModelFakeFirst.php
+++ b/tests/Feature/Management/Fakes/ManagedModelFakeFirst.php
@@ -14,23 +14,37 @@ use Thinktomorrow\AssetLibrary\HasAsset;
 use Thinktomorrow\Chief\States\State\StatefulContract;
 use Thinktomorrow\Chief\States\Publishable\Publishable;
 use Thinktomorrow\Chief\Concerns\Translatable\Translatable;
+use Thinktomorrow\Chief\DynamicAttributes\HasDynamicAttributes;
 use Thinktomorrow\Chief\Concerns\Translatable\TranslatableContract;
 use Thinktomorrow\Chief\Relations\ActingAsChild;
 use Thinktomorrow\Chief\Relations\ActingAsParent;
 use Thinktomorrow\Chief\Relations\ActsAsParent;
+use \Astrotomic\Translatable\Translatable as BaseTranslatable;
 
 class ManagedModelFakeFirst extends Model implements ManagedModel, TranslatableContract, HasAsset, ActsAsParent, ActsAsChild, StatefulContract
 {
     private $current_state = 'draft';
 
-    use Translatable,
-        \Astrotomic\Translatable\Translatable,
-        AssetTrait,
+    use HasDynamicAttributes {
+        HasDynamicAttributes::fill as hasDynamicAttributesFill;
+        HasDynamicAttributes::getAttribute as private hasDynamicAttributesGetAttribute;
+        HasDynamicAttributes::setAttribute as hasDynamicAttributesSetAttribute;
+    }
+
+    use Translatable;
+    use BaseTranslatable {
+        BaseTranslatable::getAttribute as private baseTranslatableGetAttribute;
+        BaseTranslatable::fill as baseTranslatableFill;
+        BaseTranslatable::setAttribute as baseTranslatableSetAttribute;
+    }
+
+    use AssetTrait,
         Publishable,
         ActingAsParent,
         ActingAsChild;
 
     public $table = 'fake_managed_models';
+    public $dynamicAttributes = ['dynamic_column'];
     public $translatedAttributes = ['title_trans', 'content_trans', 'slug'];
     public $guarded = [];
 
@@ -41,11 +55,11 @@ class ManagedModelFakeFirst extends Model implements ManagedModel, TranslatableC
 
     public static function managedModelKey(): string
     {
-        if(isset(static::$managedModelKey)){
+        if (isset(static::$managedModelKey)) {
             return static::$managedModelKey;
         }
 
-        throw new \Exception('Missing required static property \'managedModelKey\' on ' . static::class. '.');
+        throw new \Exception('Missing required static property \'managedModelKey\' on ' . static::class . '.');
     }
 
     public static function migrateUp()
@@ -55,6 +69,7 @@ class ManagedModelFakeFirst extends Model implements ManagedModel, TranslatableC
             $table->string('title')->nullable();
             $table->string('custom_column')->nullable();
             $table->string('current_state')->default(PageState::DRAFT);
+            $table->json('values')->nullable(); // dynamic attributes
             $table->dateTime('archived_at')->nullable();
             $table->timestamps();
         });
@@ -101,5 +116,30 @@ class ManagedModelFakeFirst extends Model implements ManagedModel, TranslatableC
     public function changeStateOf($key, $state)
     {
         $this->current_state = $state;
+    }
+
+    public function fill(array $attributes)
+    {
+        $this->hasDynamicAttributesFill($attributes);
+
+        return $this->baseTranslatableFill($attributes);
+    }
+
+    public function getAttribute($key)
+    {
+        if($value = $this->hasDynamicAttributesGetAttribute($key)) {
+            return $value;
+        }
+
+        return $this->baseTranslatableGetAttribute($key);
+    }
+
+    public function setAttribute($key, $value)
+    {
+        if ($this->isDynamicAttributeKey($key)) {
+            return $this->hasDynamicAttributesSetAttribute($key, $value);
+        }
+
+        return $this->baseTranslatableSetAttribute($key, $value);
     }
 }

--- a/tests/Feature/Management/Fakes/ManagedModelFakeFirst.php
+++ b/tests/Feature/Management/Fakes/ManagedModelFakeFirst.php
@@ -44,7 +44,7 @@ class ManagedModelFakeFirst extends Model implements ManagedModel, TranslatableC
         ActingAsChild;
 
     public $table = 'fake_managed_models';
-    public $dynamicAttributes = ['dynamic_column'];
+    public $dynamicKeys = ['dynamic_column'];
     public $translatedAttributes = ['title_trans', 'content_trans', 'slug'];
     public $guarded = [];
 
@@ -136,7 +136,7 @@ class ManagedModelFakeFirst extends Model implements ManagedModel, TranslatableC
 
     public function setAttribute($key, $value)
     {
-        if ($this->isDynamicAttributeKey($key)) {
+        if ($this->isDynamicKey($key)) {
             return $this->hasDynamicAttributesSetAttribute($key, $value);
         }
 

--- a/tests/Feature/Management/Fakes/ManagerFake.php
+++ b/tests/Feature/Management/Fakes/ManagerFake.php
@@ -5,6 +5,7 @@ namespace Thinktomorrow\Chief\Tests\Feature\Management\Fakes;
 use Illuminate\Http\Request;
 use Thinktomorrow\Chief\Fields\Types\Field;
 use Thinktomorrow\Chief\Fields\Types\FileField;
+use Thinktomorrow\Chief\Fields\Types\TextField;
 use Thinktomorrow\Chief\Fields\Types\InputField;
 use Thinktomorrow\Chief\Fields\Types\ImageField;
 use Thinktomorrow\Chief\Management\AbstractManager;
@@ -20,6 +21,7 @@ class ManagerFake extends AbstractManager implements Manager
             InputField::make('custom'),
             InputField::make('title_trans')->translatable(['nl', 'fr']),
             InputField::make('content_trans')->translatable(['nl', 'fr']),
+            TextField::make('dynamic_column'),
             ImageField::make('avatar'),
             FileField::make('hero')
         );

--- a/tests/Feature/Management/StoreManagerTest.php
+++ b/tests/Feature/Management/StoreManagerTest.php
@@ -76,6 +76,67 @@ class StoreManagerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_dynamic_field()
+    {
+        $this->asAdmin()
+            ->post($this->fake->route('store'), [
+                'dynamic_column' => 'dynamic value',
+            ]);
+
+        $first = ManagedModelFakeFirst::first();
+
+        $this->assertEquals('dynamic value', $first->dynamic('dynamic_column'));
+        $this->assertEquals('dynamic value', $first->dynamic_column);
+    }
+
+    /** @test */
+    public function it_can_create_a_dynamic_localized_field()
+    {
+        $this->asAdmin()
+            ->post($this->fake->route('store'), [
+                'trans' => [
+                    'nl' => [
+                        'dynamic_column' => 'dynamic value nl',
+                    ],
+                    'en' => [
+                        'dynamic_column' => 'dynamic value en',
+                    ]
+                ],
+            ]);
+
+        $first = ManagedModelFakeFirst::first();
+
+        $this->assertEquals('dynamic value nl', $first->dynamic_column);
+        $this->assertEquals('dynamic value en', $first->dynamic('dynamic_column','en'));
+    }
+
+    /** @test */
+    public function it_can_create_a_dynamic_localized_field_alongside_a_translatable_one()
+    {
+        $this->asAdmin()
+            ->post($this->fake->route('store'), [
+                'trans' => [
+                    'nl' => [
+                        'dynamic_column' => 'dynamic value nl',
+                        'title_trans' => 'title-nl-created',
+                    ],
+                    'en' => [
+                        'dynamic_column' => 'dynamic value en',
+                        'title_trans' => 'title-en-created',
+                    ]
+                ],
+            ]);
+
+        $first = ManagedModelFakeFirst::first();
+
+        $this->assertEquals('title-nl-created', $first->title_trans);
+        $this->assertEquals('title-en-created', $first->getTranslationFor('title_trans', 'en'));
+
+        $this->assertEquals('dynamic value nl', $first->dynamic_column);
+        $this->assertEquals('dynamic value en', $first->dynamic('dynamic_column','en'));
+    }
+
+    /** @test */
     public function it_can_upload_a_file_field()
     {
         $this->asAdmin()

--- a/tests/Feature/Management/UpdateManagerTest.php
+++ b/tests/Feature/Management/UpdateManagerTest.php
@@ -75,6 +75,67 @@ class UpdateManagerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_dynamic_field()
+    {
+        $this->asAdmin()
+            ->put($this->fake->route('update'), [
+                'dynamic_column' => 'dynamic value',
+            ]);
+
+        $first = ManagedModelFakeFirst::first();
+
+        $this->assertEquals('dynamic value', $first->dynamic('dynamic_column'));
+        $this->assertEquals('dynamic value', $first->dynamic_column);
+    }
+
+    /** @test */
+    public function it_can_create_a_dynamic_localized_field()
+    {
+        $this->asAdmin()
+            ->put($this->fake->route('update'), [
+                'trans' => [
+                    'nl' => [
+                        'dynamic_column' => 'dynamic value nl',
+                    ],
+                    'en' => [
+                        'dynamic_column' => 'dynamic value en',
+                    ]
+                ],
+            ]);
+
+        $first = ManagedModelFakeFirst::first();
+
+        $this->assertEquals('dynamic value nl', $first->dynamic_column);
+        $this->assertEquals('dynamic value en', $first->dynamic('dynamic_column','en'));
+    }
+
+    /** @test */
+    public function it_can_create_a_dynamic_localized_field_alongside_a_translatable_one()
+    {
+        $this->asAdmin()
+            ->put($this->fake->route('update'), [
+                'trans' => [
+                    'nl' => [
+                        'dynamic_column' => 'dynamic value nl',
+                        'title_trans' => 'title-nl-created',
+                    ],
+                    'en' => [
+                        'dynamic_column' => 'dynamic value en',
+                        'title_trans' => 'title-en-created',
+                    ]
+                ],
+            ]);
+
+        $first = ManagedModelFakeFirst::first();
+
+        $this->assertEquals('title-nl-created', $first->title_trans);
+        $this->assertEquals('title-en-created', $first->getTranslationFor('title_trans', 'en'));
+
+        $this->assertEquals('dynamic value nl', $first->dynamic_column);
+        $this->assertEquals('dynamic value en', $first->dynamic('dynamic_column','en'));
+    }
+
+    /** @test */
     public function it_can_update_a_media_field()
     {
         $this->asAdmin()

--- a/tests/Unit/DynamicAttributes/HasDynamicAttributesTest.php
+++ b/tests/Unit/DynamicAttributes/HasDynamicAttributesTest.php
@@ -71,4 +71,17 @@ class HasDynamicAttributesTest extends TestCase
         $this->assertEquals('title value', $model->dynamic('title'));
         $this->assertEquals('title value', $model->title);
     }
+
+    /** @test */
+    function it_can_save_a_localized_dynamic_attribute()
+    {
+        $model = new ModelStub(['values' => []]);
+        $model->title = 'title value';
+        $model->save();
+
+        $model = ModelStub::first();
+
+        $this->assertEquals('title value', $model->dynamic('title'));
+        $this->assertEquals('title value', $model->title);
+    }
 }

--- a/tests/Unit/DynamicAttributes/HasDynamicAttributesTest.php
+++ b/tests/Unit/DynamicAttributes/HasDynamicAttributesTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Thinktomorrow\Chief\Tests\Unit\DynamicAttributes;
+
+use Thinktomorrow\Chief\Tests\TestCase;
+use Thinktomorrow\Chief\DynamicAttributes\DynamicAttributes;
+
+class HasDynamicAttributesTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        ModelStub::migrateUp();
+    }
+
+        /** @test */
+    public function it_can_get_a_dynamic_attribute()
+    {
+        $model = new ModelStub(['values' => ['title' => 'title value']]);
+
+        $this->assertEquals('title value', $model->title);
+    }
+
+    /** @test */
+    function it_can_get_the_dynamic_attributes_as_value()
+    {
+        $model = new ModelStub(['values' => ['title' => 'title value']]);
+
+        $this->assertInstanceOf(DynamicAttributes::class, $model->values);
+        $this->assertEquals(['title' => 'title value'], $model->values->all());
+    }
+
+    /** @test */
+    function a_model_attribute_has_precedence_over_a_dynamic_attribute()
+    {
+        $model = new ModelStub(['title' => 'model title', 'values' => ['title' => 'title value']]);
+
+        $this->assertEquals('model title', $model->title);
+    }
+
+    /** @test */
+    function it_can_set_a_dynamic_attribute()
+    {
+        $model = new ModelStub(['values' => ['title' => 'title value']]);
+        $model->title = 'new title value';
+
+        $this->assertEquals('new title value', $model->dynamic('title'));
+        $this->assertEquals('new title value', $model->title);
+    }
+
+    /** @test */
+    function it_can_set_a_new_dynamic_attribute()
+    {
+        $model = new ModelStub(['values' => []]);
+        $model->title = 'title value';
+
+        $this->assertEquals('title value', $model->dynamic('title'));
+        $this->assertEquals('title value', $model->title);
+    }
+
+    /** @test */
+    function it_can_save_a_dynamic_attribute()
+    {
+        $model = new ModelStub(['values' => []]);
+        $model->title = 'title value';
+        $model->save();
+
+        $model = ModelStub::first();
+
+        $this->assertEquals('title value', $model->dynamic('title'));
+        $this->assertEquals('title value', $model->title);
+    }
+}

--- a/tests/Unit/DynamicAttributes/HasDynamicAttributesTest.php
+++ b/tests/Unit/DynamicAttributes/HasDynamicAttributesTest.php
@@ -32,11 +32,14 @@ class HasDynamicAttributesTest extends TestCase
     }
 
     /** @test */
-    public function a_model_attribute_has_precedence_over_a_dynamic_attribute()
+    public function a_model_attribute_is_forced_as_dynamic_when_its_set_as_dynamic_attribute()
     {
-        $model = new ModelStub(['title' => 'model title', 'values' => ['title' => 'title value']]);
+        $model = new ModelStub(['title' => 'model title']);
 
         $this->assertEquals('model title', $model->title);
+        $this->assertEquals('model title', $model->dynamic('title'));
+
+        $this->assertEquals(new DynamicAttributes(['title' => 'model title']), $model->values);
     }
 
     /** @test */

--- a/tests/Unit/DynamicAttributes/HasDynamicAttributesTest.php
+++ b/tests/Unit/DynamicAttributes/HasDynamicAttributesTest.php
@@ -23,7 +23,7 @@ class HasDynamicAttributesTest extends TestCase
     }
 
     /** @test */
-    function it_can_get_the_dynamic_attributes_as_value()
+    public function it_can_get_the_dynamic_attributes_as_value()
     {
         $model = new ModelStub(['values' => ['title' => 'title value']]);
 
@@ -32,7 +32,7 @@ class HasDynamicAttributesTest extends TestCase
     }
 
     /** @test */
-    function a_model_attribute_has_precedence_over_a_dynamic_attribute()
+    public function a_model_attribute_has_precedence_over_a_dynamic_attribute()
     {
         $model = new ModelStub(['title' => 'model title', 'values' => ['title' => 'title value']]);
 
@@ -40,7 +40,7 @@ class HasDynamicAttributesTest extends TestCase
     }
 
     /** @test */
-    function it_can_set_a_dynamic_attribute()
+    public function it_can_set_a_dynamic_attribute()
     {
         $model = new ModelStub(['values' => ['title' => 'title value']]);
         $model->title = 'new title value';
@@ -50,7 +50,7 @@ class HasDynamicAttributesTest extends TestCase
     }
 
     /** @test */
-    function it_can_set_a_new_dynamic_attribute()
+    public function it_can_set_a_new_dynamic_attribute()
     {
         $model = new ModelStub(['values' => []]);
         $model->title = 'title value';
@@ -60,20 +60,7 @@ class HasDynamicAttributesTest extends TestCase
     }
 
     /** @test */
-    function it_can_save_a_dynamic_attribute()
-    {
-        $model = new ModelStub(['values' => []]);
-        $model->title = 'title value';
-        $model->save();
-
-        $model = ModelStub::first();
-
-        $this->assertEquals('title value', $model->dynamic('title'));
-        $this->assertEquals('title value', $model->title);
-    }
-
-    /** @test */
-    function it_can_save_a_localized_dynamic_attribute()
+    public function it_can_save_a_dynamic_attribute()
     {
         $model = new ModelStub(['values' => []]);
         $model->title = 'title value';

--- a/tests/Unit/DynamicAttributes/LocalizedDynamicAttributesTest.php
+++ b/tests/Unit/DynamicAttributes/LocalizedDynamicAttributesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Thinktomorrow\Chief\Tests\Unit\DynamicAttributes;
+
+use Thinktomorrow\Chief\Tests\TestCase;
+
+class LocalizedDynamicAttributesTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        ModelStub::migrateUp();
+    }
+
+    /** @test */
+    function it_can_get_a_localized_dynamic_attribute()
+    {
+        $model = new ModelStub(['values' => [
+            'nl' => ['title' => 'localized title nl'],
+            'en' => ['title' => 'localized title en'],
+        ]]);
+
+        app()->setLocale('nl');
+        $this->assertEquals('localized title nl', $model->title);
+
+        app()->setLocale('en');
+        $this->assertEquals('localized title en', $model->title);
+
+        $this->assertEquals('localized title en', $model->dynamic('title', 'en'));
+        $this->assertEquals('localized title nl', $model->dynamic('title', 'nl'));
+    }
+
+    /** @test */
+    function it_does_not_provide_a_fallback_localized_value()
+    {
+        $model = new ModelStub(['values' => [
+            'nl' => ['title' => 'localized title nl'],
+        ]]);
+
+        app()->setLocale('en');
+        $this->assertNull($model->title);
+    }
+
+    /** @test */
+    function it_can_be_used_along_the_translatable_trait()
+    {
+
+    }
+
+    /** @test */
+    function it_can_set_a_localized_dynamic_attribute()
+    {
+
+    }
+}

--- a/tests/Unit/DynamicAttributes/LocalizedDynamicAttributesTest.php
+++ b/tests/Unit/DynamicAttributes/LocalizedDynamicAttributesTest.php
@@ -14,7 +14,7 @@ class LocalizedDynamicAttributesTest extends TestCase
     }
 
     /** @test */
-    function it_can_get_a_localized_dynamic_attribute()
+    public function it_can_get_a_localized_dynamic_attribute()
     {
         $model = new ModelStub(['values' => [
             'nl' => ['title' => 'localized title nl'],
@@ -32,7 +32,7 @@ class LocalizedDynamicAttributesTest extends TestCase
     }
 
     /** @test */
-    function it_does_not_provide_a_fallback_localized_value()
+    public function it_does_not_provide_a_fallback_localized_value()
     {
         $model = new ModelStub(['values' => [
             'nl' => ['title' => 'localized title nl'],
@@ -43,14 +43,17 @@ class LocalizedDynamicAttributesTest extends TestCase
     }
 
     /** @test */
-    function it_can_be_used_along_the_translatable_trait()
+    public function it_can_save_a_localized_dynamic_attribute()
     {
+        $model = new ModelStub(['values' => []]);
+        $model->setDynamic('title', 'title value nl', 'nl');
+        $model->setDynamic('title', 'title value en', 'en');
+        $model->save();
 
-    }
+        $model = ModelStub::first();
 
-    /** @test */
-    function it_can_set_a_localized_dynamic_attribute()
-    {
-
+        $this->assertEquals('title value nl', $model->dynamic('title', 'nl'));
+        $this->assertEquals('title value en', $model->dynamic('title', 'en'));
+        $this->assertEquals('title value nl', $model->title); // app locale is nl
     }
 }

--- a/tests/Unit/DynamicAttributes/ModelStub.php
+++ b/tests/Unit/DynamicAttributes/ModelStub.php
@@ -12,7 +12,7 @@ class ModelStub extends Model
 {
     use HasDynamicAttributes;
 
-    protected $dynamicAttributes = [
+    protected $dynamicKeys = [
         'title',
     ];
 

--- a/tests/Unit/DynamicAttributes/ModelStub.php
+++ b/tests/Unit/DynamicAttributes/ModelStub.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Thinktomorrow\Chief\Tests\Unit\DynamicAttributes;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Thinktomorrow\Chief\DynamicAttributes\HasDynamicAttributes;
+
+class ModelStub extends Model
+{
+    use HasDynamicAttributes;
+
+    protected $dynamicAttributes = [
+        'title',
+    ];
+
+    protected $guarded = [];
+
+    public static function migrateUp()
+    {
+        Schema::create('model_stubs', function (Blueprint $table) {
+            $table->increments('id');
+            $table->json('values')->nullable();
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/Unit/Fields/ArrangingFieldsTest.php
+++ b/tests/Unit/Fields/ArrangingFieldsTest.php
@@ -82,10 +82,10 @@ class ArrangingFieldsTest extends TestCase
         $arrangement = $this->manager->fieldArrangement();
 
         $this->assertFalse($arrangement->hasTabs());
-        $this->assertCount(6, $arrangement->fields());
+        $this->assertCount(7, $arrangement->fields());
         $this->assertEquals('title', $arrangement->fields()->keys()[0]);
-        $this->assertEquals('avatar', $arrangement->fields()->keys()[4]);
-        $this->assertEquals('hero', $arrangement->fields()->keys()[5]);
+        $this->assertEquals('avatar', $arrangement->fields()->keys()[5]);
+        $this->assertEquals('hero', $arrangement->fields()->keys()[6]);
     }
 
     /** @test */


### PR DESCRIPTION
dynamic attributes provide a way to easily set up model values.
This will reduce the need to create a migration for each added model attribute.
