### PR TITLE
Add: chief frontend toast for quick edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ principles.
 
 ## unreleased
 - Added: Pagefield used to select an internal page
+- Added: chief admin toast - a widget element on frontend for quick page edit and preview mode toggle
 - Added: dynamic attributes. [https://thinktomorrow.github.io/package-docs/src/chief/managers.html#dynamic-attributes](view docs)
 - Added: `Manager::editView()` and `Manager::createView` provide the option to customise the view filepath for the create and edit admin views.
 - Added: `Manager::editFields()` and `Manager::createFields` provide the fields for respectively the create and edit form views.
@@ -19,6 +20,7 @@ principles.
 - Changed: baseUrlSegment method is no longer a static method and requires to be an instance method.
 - Changed: Moved the Healthmonitor classes to the `src/System` directory. You'll need to update your chief.php monitor entries.
 - Fixed: Creating own modules for pages with custom tables now works as expected.
+- Removed: `ManagedModel::previewUrl()`. Use the `ManagedModel::url()` instead.
 - Removed: the `$manager` instance is no longer available inside a field view. You can always pass this to the view via the `Field::viewData()` method.
 - Removed: `Manager::fieldValue()` and `Manager::renderField()` methods. A field is now responsible for rendering its content, not the manager.
 - Removed: `RenderingFields` trait as the methods `Manager::fieldValue()` and `Manager::renderField()` are no longer being used.

--- a/app/Http/Controllers/Back/Assistants/PublishController.php
+++ b/app/Http/Controllers/Back/Assistants/PublishController.php
@@ -22,7 +22,7 @@ class PublishController extends Controller
 
         $manager->assistant('publish')->publish();
 
-        return redirect()->back()->with('messages.success', $manager->details()->title . ' is gepubliceerd. <a href="' . $manager->assistant('publish')->previewUrl() . '" target="_blank">Bekijk de pagina online</a>.');
+        return redirect()->back()->with('messages.success', $manager->details()->title . ' is gepubliceerd. <a href="' . $manager->assistant('publish')->url() . '" target="_blank">Bekijk de pagina online</a>.');
     }
 
     public function unpublish(Request $request, $key, $id)

--- a/composer.lock
+++ b/composer.lock
@@ -992,16 +992,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v6.18.3",
+            "version": "v6.18.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "4e48acfaba87f08320a2764d36c3b6a4a4112ccf"
+                "reference": "4ef5f9612c2694c915f53f0cec3e4081e9bfc778"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/4e48acfaba87f08320a2764d36c3b6a4a4112ccf",
-                "reference": "4e48acfaba87f08320a2764d36c3b6a4a4112ccf",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/4ef5f9612c2694c915f53f0cec3e4081e9bfc778",
+                "reference": "4ef5f9612c2694c915f53f0cec3e4081e9bfc778",
                 "shasum": ""
             },
             "require": {
@@ -1134,20 +1134,20 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2020-03-24T16:37:50+00:00"
+            "time": "2020-04-08T15:51:23+00:00"
         },
         {
             "name": "league/commonmark",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "75542a366ccbe1896ed79fcf3e8e68206d6c4257"
+                "reference": "5a67afc2572ec6d430526cdc9c637ef124812389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/75542a366ccbe1896ed79fcf3e8e68206d6c4257",
-                "reference": "75542a366ccbe1896ed79fcf3e8e68206d6c4257",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/5a67afc2572ec6d430526cdc9c637ef124812389",
+                "reference": "5a67afc2572ec6d430526cdc9c637ef124812389",
                 "shasum": ""
             },
             "require": {
@@ -1208,7 +1208,7 @@
                 "md",
                 "parser"
             ],
-            "time": "2020-03-25T19:55:28+00:00"
+            "time": "2020-04-05T16:01:48+00:00"
         },
         {
             "name": "league/flysystem",
@@ -1672,16 +1672,6 @@
                 "date",
                 "datetime",
                 "time"
-            ],
-            "funding": [
-                {
-                    "url": "https://opencollective.com/Carbon",
-                    "type": "open_collective"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-31T13:43:19+00:00"
         },
@@ -2496,12 +2486,6 @@
                 "spatie",
                 "user"
             ],
-            "funding": [
-                {
-                    "url": "https://spatie.be/open-source/support-us",
-                    "type": "custom"
-                }
-            ],
             "time": "2020-03-23T17:09:07+00:00"
         },
         {
@@ -2997,20 +2981,6 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T11:41:10+00:00"
         },
         {
@@ -3064,20 +3034,6 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:56:45+00:00"
         },
         {
@@ -3134,20 +3090,6 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -3209,20 +3151,6 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T11:42:42+00:00"
         },
         {
@@ -3279,20 +3207,6 @@
             ],
             "description": "Symfony ErrorHandler Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T14:07:33+00:00"
         },
         {
@@ -3363,20 +3277,6 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -3484,20 +3384,6 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -3553,20 +3439,6 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T14:07:33+00:00"
         },
         {
@@ -3657,20 +3529,6 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T14:59:15+00:00"
         },
         {
@@ -3732,20 +3590,6 @@
             "keywords": [
                 "mime",
                 "mime-type"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-27T16:56:45+00:00"
         },
@@ -4147,20 +3991,6 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -4236,20 +4066,6 @@
                 "routing",
                 "uri",
                 "url"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-30T11:41:10+00:00"
         },
@@ -4385,20 +4201,6 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -4531,20 +4333,6 @@
             "keywords": [
                 "debug",
                 "dump"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-27T16:54:36+00:00"
         },
@@ -4820,16 +4608,16 @@
         },
         {
             "name": "tightenco/collect",
-            "version": "v7.4.0",
+            "version": "v7.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tightenco/collect.git",
-                "reference": "5024db45b1ec1956e6d5959cbb5cdf5f00f26f56"
+                "reference": "1f5f7a36657a126fa035c7cfaafd738391690967"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tightenco/collect/zipball/5024db45b1ec1956e6d5959cbb5cdf5f00f26f56",
-                "reference": "5024db45b1ec1956e6d5959cbb5cdf5f00f26f56",
+                "url": "https://api.github.com/repos/tightenco/collect/zipball/1f5f7a36657a126fa035c7cfaafd738391690967",
+                "reference": "1f5f7a36657a126fa035c7cfaafd738391690967",
                 "shasum": ""
             },
             "require": {
@@ -4866,7 +4654,7 @@
                 "collection",
                 "laravel"
             ],
-            "time": "2020-03-31T17:56:15+00:00"
+            "time": "2020-04-08T17:29:27+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -5930,20 +5718,6 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "funding": [
-                {
-                    "url": "https://github.com/ondrejmirtes",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-22T16:51:47+00:00"
         },
         {
@@ -6278,16 +6052,6 @@
                 "phpunit",
                 "testing",
                 "xunit"
-            ],
-            "funding": [
-                {
-                    "url": "https://phpunit.de/donate.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
             ],
             "time": "2020-03-31T08:52:04+00:00"
         },
@@ -7004,6 +6768,5 @@
         "php": "^7.2.0",
         "ext-json": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }

--- a/resources/views/back/managers/_partials/context-menu.blade.php
+++ b/resources/views/back/managers/_partials/context-menu.blade.php
@@ -1,8 +1,8 @@
 <options-dropdown class="inline-block">
     <div class="inset-s" v-cloak>
 
-        @if($manager->isAssistedBy('publish') && $manager->assistant('publish')->hasPreviewUrl())
-            <a class="block p-3 --link-with-bg" href="{!! $manager->assistant('publish')->previewUrl() !!}" target="_blank">Bekijk preview</a>
+        @if($manager->isAssistedBy('publish') && $manager->assistant('publish')->hasUrl())
+            <a class="block p-3 --link-with-bg" href="{!! $manager->assistant('publish')->url() !!}" target="_blank">Bekijk op site</a>
         @endif
 
         @if($manager->can('edit') && request()->fullUrl() !== $manager->route('edit'))

--- a/resources/views/front/admin-toast.blade.php
+++ b/resources/views/front/admin-toast.blade.php
@@ -1,0 +1,40 @@
+@if(chiefAdmin())
+<?php
+
+    // find model by this url, get manager, set model and then get route for edit
+    $editUrl = null;
+
+    try{
+        $manager = app(\Thinktomorrow\Chief\Management\Managers::class)->findByUrl(request()->path(), app()->getLocale());
+
+        $editUrl = $manager->can('edit') ? $manager->route('edit') : null;
+
+    } catch(Exception $e)
+    {
+        //
+    }
+
+    $inPreviewMode = session()->get('preview-mode', false);
+    $previewModeToggleUrl = route('chief.front.preview');
+
+?>
+<!-- chief admin toast -->
+<div id="chiefAdminToast" style="position: fixed; top: 0; left: 0; background-color: white; color: black; z-index: 9999; margin-left: -1px; margin-top: -1px; border: 1px solid; border-bottom-right-radius: .5em;">
+    @if($editUrl)
+        <a style="display:inline-block; padding:.6rem;" href="{{ $editUrl }}" title="Bewerk deze pagina in chief">
+            <svg style="display:inline-block;" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line>
+            </svg>
+        </a> |
+    @endif
+    <a style="display: inline-block; padding:.6rem;" href="{{ $previewModeToggleUrl }}" title="{{ $inPreviewMode ? 'Schakel preview uit: verberg offline pagina\'s' : 'Schakel preview aan: toon offline pagina\'s' }}">Preview {{ $inPreviewMode ? 'aan' : 'uit' }}</a>
+    <span style="display: inline-block; padding:.6rem; cursor:pointer;" data-chief-toast-close>x</span>
+</div>
+<script>
+    var chiefAdminToast = document.getElementById('chiefAdminToast');
+
+    chiefAdminToast.querySelector('[data-chief-toast-close]').addEventListener('click', function(){
+        chiefAdminToast.classList.add('hidden');
+    });
+</script>
+@endif

--- a/routes/chief-admin-routes.php
+++ b/routes/chief-admin-routes.php
@@ -9,6 +9,13 @@
 // Dashboard
 Route::get('/', 'Thinktomorrow\Chief\App\Http\Controllers\Back\DashboardController@show')->name('chief.back.dashboard');
 
+// Toggle preview mode on frontend chief admin toast
+Route::get('toggle-preview', function(){
+    session()->put('preview-mode', !session()->get('preview-mode',false));
+
+    return redirect()->back();
+} )->name('chief.front.preview');
+
 /**
 * -----------------------------------------------------------------
 * MANAGER ROUTES

--- a/src/Management/Assistants/PublishAssistant.php
+++ b/src/Management/Assistants/PublishAssistant.php
@@ -119,9 +119,9 @@ class PublishAssistant implements Assistant
         return $this;
     }
 
-    public function hasPreviewUrl(): bool
+    public function hasUrl(): bool
     {
-        return $this->manager->existingModel() instanceof ProvidesUrl && $this->previewUrl() != '?preview-mode';
+        return $this->manager->existingModel() instanceof ProvidesUrl;
     }
 
     public function publicationStatusAsLabel($plain = false)
@@ -139,8 +139,8 @@ class PublishAssistant implements Assistant
 
         $statusAsLabel = '<span class="' . $class . '">' . $label . '</span>';
 
-        if (!$plain && $this->hasPreviewUrl()) {
-            $statusAsLabel = '<a href="' . $this->previewUrl() . '" target="_blank">' . $statusAsLabel . '</a>';
+        if (!$plain && $this->hasUrl()) {
+            $statusAsLabel = '<a href="' . $this->url() . '" target="_blank">' . $statusAsLabel . '</a>';
         }
 
         return $statusAsLabel;
@@ -159,8 +159,8 @@ class PublishAssistant implements Assistant
         return '-';
     }
 
-    public function previewUrl(): string
+    public function url(): string
     {
-        return $this->manager->existingModel()->previewUrl();
+        return $this->manager->existingModel()->url();
     }
 }

--- a/src/Management/Managers.php
+++ b/src/Management/Managers.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Thinktomorrow\Chief\Management;
 
 use Illuminate\Support\Collection;
+use Thinktomorrow\Chief\Concerns\Morphable\Morphables;
+use Thinktomorrow\Chief\Urls\UrlRecord;
 
 class Managers
 {
@@ -40,6 +42,15 @@ class Managers
         $registration = $this->register->filterByModel($model)->first();
 
         return $this->instance($registration, $id);
+    }
+
+    public function findByUrl(string $slug, string $locale): Manager
+    {
+        $urlRecord = UrlRecord::findBySlug($slug, $locale);
+
+        $model = Morphables::instance($urlRecord->model_type)->find($urlRecord->model_id);
+
+        return $this->findByModel($model);
     }
 
     /**

--- a/src/Pages/Application/DeletePage.php
+++ b/src/Pages/Application/DeletePage.php
@@ -6,9 +6,7 @@ namespace Thinktomorrow\Chief\Pages\Application;
 
 use Illuminate\Support\Facades\DB;
 use Thinktomorrow\Chief\Modules\Module;
-use Thinktomorrow\Chief\Pages\Page;
 use Thinktomorrow\Chief\Audit\Audit;
-use Thinktomorrow\Chief\FlatReferences\FlatReferenceFactory;
 use Thinktomorrow\Chief\Urls\UrlRecord;
 use Thinktomorrow\Chief\States\PageState;
 

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -216,17 +216,6 @@ class Page extends Model implements ManagedModel, TranslatableContract, HasAsset
     }
 
     /** @inheritdoc */
-    public function previewUrl(string $locale = null): string
-    {
-        if($this->isPublished()) {
-            return $this->url($locale);
-        }
-
-        return $this->url($locale) . '?preview-mode';
-    }
-
-
-    /** @inheritdoc */
     public function baseUrlSegment(string $locale = null): string
     {
         if (!isset(static::$baseUrlSegment)) {
@@ -265,7 +254,7 @@ class Page extends Model implements ManagedModel, TranslatableContract, HasAsset
         }
 
         if ($this->isDraft()) {
-            return '<a href="' . $this->previewUrl() . '" target="_blank" class="text-error"><em>offline</em></a>';
+            return '<a href="' . $this->url() . '" target="_blank" class="text-error"><em>offline</em></a>';
         }
 
         if ($this->isArchived()) {

--- a/src/States/Publishable/PreviewMode.php
+++ b/src/States/Publishable/PreviewMode.php
@@ -15,7 +15,7 @@ class PreviewMode
 
     public static function fromRequest()
     {
-        $active = (request()->has('preview-mode') && auth()->guard('chief')->check());
+        $active = (session()->get('preview-mode') === true && auth()->guard('chief')->check());
 
         return new static($active);
     }

--- a/src/Urls/ProvidesUrl/ProvidesUrl.php
+++ b/src/Urls/ProvidesUrl/ProvidesUrl.php
@@ -15,14 +15,6 @@ interface ProvidesUrl
     public function url(string $locale = null): string;
 
     /**
-     * Same as url() but used for admins to allow them to view drafted urls.
-     *
-     * @param null|string $locale
-     * @return string
-     */
-    public function previewUrl(string $locale = null): string;
-
-    /**
      * The base category uri segment for this type of model.
      * e.g. /news/, /events/.
      *

--- a/tests/Feature/Urls/ChiefResponseTest.php
+++ b/tests/Feature/Urls/ChiefResponseTest.php
@@ -80,7 +80,8 @@ class ChiefResponseTest extends TestCase
 
         UrlRecord::create(['locale' => 'nl', 'slug' => 'foo/bar', 'model_type' => $model->morphKey(), 'model_id' => $model->id]);
 
-        $response = $this->asAdmin()->get('foo/bar?preview-mode');
+        session()->flash('preview-mode', true);
+        $response = $this->asAdmin()->get('foo/bar');
 
         $response->assertSuccessful();
     }

--- a/tests/Feature/Urls/Fakes/ProductFake.php
+++ b/tests/Feature/Urls/Fakes/ProductFake.php
@@ -26,11 +26,6 @@ class ProductFake extends ManagedModelFakeFirst implements ProvidesUrl, Provides
         return UrlRecord::findByModel($this, $locale)->slug;
     }
 
-    public function previewUrl(string $locale = null): string
-    {
-        return $this->url($locale);
-    }
-
     /** @inheritdoc */
     public function baseUrlSegment(string $locale = null): string
     {

--- a/tests/fakes/CustomTableArticleFake.php
+++ b/tests/fakes/CustomTableArticleFake.php
@@ -111,13 +111,6 @@ class CustomTableArticleFake extends Model implements ManagedModel, HasAsset, Ac
     }
 
     /** @inheritdoc */
-    public function previewUrl(string $locale = null): string
-    {
-        return $this->url($locale) . '?preview-mode';
-    }
-
-
-    /** @inheritdoc */
     public function baseUrlSegment(string $locale = null): string
     {
         if (!isset(static::$baseUrlSegment)) {


### PR DESCRIPTION
## Small chief toast for quick edit link for the current visited page. 
This also allows for the admin to toggle preview mode.  This PR will remove the need to add `?preview-mode`to the end of the url. The preview mode is now taken care of via the session instead. 

![image](https://user-images.githubusercontent.com/497668/79149048-ce846080-7dc6-11ea-9a01-0b0de850a9a8.png)


## How to include:
add the path to the viewfile in your projects layout file. You can add the following include snippet:
```html
<body>
  @include('chief::front.admin-toast')
</body>
```

## TODO
There is still some layout and UX enhancements needed. But the basic functionality is in place.