### PR TITLE
add chief guard to fetching user from request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ principles.
 
 ## unreleased
 - Fixed: issue where chief error page is shown when path contains the 'admin' string.
+- Fixed: added chief guard when fetching user out of request to prevent conflict with front end logins.
 
 ## 0.5.2 - 2020-18-05
 - Added: option to add charactercount to textfield and inputfield. Added this to default seo description and seo title fields.

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace Thinktomorrow\Chief\App\Exceptions;
 
 use Exception;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\Access\AuthorizationException;

--- a/app/Http/Middleware/AuthenticateChiefSession.php
+++ b/app/Http/Middleware/AuthenticateChiefSession.php
@@ -17,23 +17,23 @@ class AuthenticateChiefSession
 
     public function handle($request, Closure $next)
     {
-        if (! $request->user() || ! $request->session()) {
+        if (! $request->user('chief') || ! $request->session()) {
             return $next($request);
         }
 
         if ($this->auth->viaRemember()) {
             $passwordHash = explode('|', $request->cookies->get($this->auth->getRecallerName()))[2];
 
-            if ($passwordHash != $request->user()->getAuthPassword()) {
+            if ($passwordHash != $request->user('chief')->getAuthPassword()) {
                 $this->logout($request);
             }
         }
 
-        if (! $request->session()->has('password_hash')) {
+        if (! $request->session()->has('chief_password_hash')) {
             $this->storePasswordHashInSession($request);
         }
 
-        if ($request->session()->get('password_hash') !== $request->user()->getAuthPassword()) {
+        if ($request->session()->get('chief_password_hash') !== $request->user('chief')->getAuthPassword()) {
             $this->logout($request);
         }
 
@@ -50,12 +50,12 @@ class AuthenticateChiefSession
      */
     protected function storePasswordHashInSession($request)
     {
-        if (! $request->user()) {
+        if (! $request->user('chief')) {
             return;
         }
 
         $request->session()->put([
-            'password_hash' => $request->user()->getAuthPassword(),
+            'chief_password_hash' => $request->user('chief')->getAuthPassword(),
             ]);
     }
 
@@ -71,7 +71,7 @@ class AuthenticateChiefSession
     {
         $this->auth->logout();
 
-        $request->session()->flush();
+        $request->session()->remove('chief_password_hash');
 
         throw new AuthenticationException();
     }

--- a/app/Http/Middleware/PermissionMiddleware.php
+++ b/app/Http/Middleware/PermissionMiddleware.php
@@ -20,7 +20,7 @@ class PermissionMiddleware
             return redirect('/');
         }
 
-        if (! $request->user()->can($permission)) {
+        if (! $request->user('chief')->can($permission)) {
             abort(403);
         }
 

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -20,11 +20,11 @@ class RoleMiddleware
             return redirect('/');
         }
 
-        if (! $request->user()->hasRole($role)) {
+        if (! $request->user('chief')->hasRole($role)) {
             abort(403);
         }
 
-        if (! $request->user()->can($permission)) {
+        if (! $request->user('chief')->can($permission)) {
             abort(403);
         }
 


### PR DESCRIPTION
This change is needed to prevent conflicts between extra logins on the front end and the chief login. If we dont state the chief guard here there is a chance that the front end user might be fetched from the session instead of the chief user